### PR TITLE
Syslog support

### DIFF
--- a/bin/ape.conf
+++ b/bin/ape.conf
@@ -17,6 +17,7 @@ Server {
 Log {
 	debug = 1
 	use_syslog = 0
+	syslog_facility = local2
 	logfile = ./ape.log
 }
 


### PR DESCRIPTION
Hey, I picked up a patch from the mailinglist and enhanced it a little bit so that you can pick the facility to log to via the config file.

Syslog support for APE is very important because you can't rotate APE's logs otherwise without restarting it, which is bad in a production environment.
