### PR TITLE
Fix double free bug, Issue #14

### DIFF
--- a/src/sock.c
+++ b/src/sock.c
@@ -196,6 +196,9 @@ void setnonblocking(int fd)
 }
 
 /* Close socket but preserve ape_socket struct */
+/* Needs to handle being called on a socket already closed.
+   At least on MacOS there are multiple events delivered simultaneously
+   that result in multiple calls to close. */
 void close_socket(int fd, acetables *g_ape)
 {
 	ape_socket *co = g_ape->co[fd];
@@ -209,6 +212,7 @@ void close_socket(int fd, acetables *g_ape)
 
 	if (co->buffer_in.data != NULL) {
 		free(co->buffer_in.data);
+		co->buffer_in.data = NULL;
 	}
 
 	if (co->parser.data != NULL) {


### PR DESCRIPTION
Clear the buffer_in.data pointer in close_socket() so that a subsequent call to close the same socket again will not result in an attempt to free a buffer previously freed. On MacOS (10.7.2 at least) it is the case that
the same fd will be reported multiple times from one call to kevent(),
which means one call to the events_poll() on this platform.  It seems like
this may be a bug with kevent; I don't see how it is being used improperly
to result in double events this way.  In any case, what crashes aped
is the double free from calling close_socket() twice, and it is better
to clear the pointer anyway which avoids the double free and hence the crash.
Fixes Issue #14
