### PR TITLE
JSONP and unescaped JSON problems

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -226,6 +226,10 @@ static int escape_json_string(char *in, char *out, int len)
 				out[e++] = '\\';
 				out[e] = 'r';
 				break;
+			case '\'':
+				out[e++] = '\\';
+				out[e] = '\'';
+				break;
 			default: 
 				out[e] = in[i];
 				break;


### PR DESCRIPTION
Fix a JSONP problem with unescaped JSON (see: http://ape-project.lighthouseapp.com/projects/39102/tickets/73-jsonp-does-not-escape-single-qoutes-in-apetransportread).
