### PR TITLE
APE_Server segfault and memory leak fixes.

### DIFF
--- a/scripts/framework/Http.js
+++ b/scripts/framework/Http.js
@@ -140,13 +140,12 @@ var Http = new Class({
 						var tmpHeaders = tmp[i].split(": ");
 						this.responseHeaders[tmpHeaders[0]] = tmpHeaders[1];
 					}
-				} else {
-					if ($defined(this.responseHeaders['Content-Length']) && this.getContentSize() >= this.responseHeaders['Content-Length']) {
-						this.socket.close();
-					} 
-					if ($defined(this.responseHeaders['Location'])) {
-						socket.close();
-					}
+				}
+				if ($defined(this.responseHeaders['Content-Length']) && this.getContentSize() >= this.responseHeaders['Content-Length']) {
+					this.socket.close();
+				} 
+				if ($defined(this.responseHeaders['Location'])) {
+					socket.close();
 				}
 			}				
 		}.bind(this);

--- a/src/log.c
+++ b/src/log.c
@@ -144,8 +144,8 @@ void ape_log(ape_log_lvl_t lvl, const char *file, unsigned long int line, acetab
 			}
 			write(g_ape->logs.fd, buff, len);
 			write(g_ape->logs.fd, "\n", 1);
-
-			free(buff);
 		}
+
+		free(buff);
 	}
 }

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -232,7 +232,7 @@ void proxy_shutdown(ape_proxy *proxy, acetables *g_ape)
 {
 
 	if (proxy->state == PROXY_CONNECTED) {
-		shutdown(proxy->sock.fd, 2);
+		safe_shutdown(proxy->sock.fd, g_ape);
 		proxy->state = PROXY_TOFREE;
 	}
 	if (proxy->prev != NULL) {

--- a/src/transports.c
+++ b/src/transports.c
@@ -51,13 +51,13 @@ struct _transport_open_same_host_p transport_open_same_host(subuser *sub, ape_so
 	return ret;
 }
 
-void transport_data_completly_sent(subuser *sub, transport_t transport)
+void transport_data_completly_sent(subuser *sub, transport_t transport, acetables *g_ape)
 {
 	switch(transport) {
 		case TRANSPORT_LONGPOLLING:
 		case TRANSPORT_JSONP:
 		default:
-			do_died(sub);
+			do_died(sub, g_ape);
 			break;
 		case TRANSPORT_PERSISTANT:
 		case TRANSPORT_XHRSTREAMING:

--- a/src/transports.h
+++ b/src/transports.h
@@ -46,7 +46,7 @@ typedef enum {
 
 
 struct _transport_open_same_host_p transport_open_same_host(subuser *sub, ape_socket *client, transport_t transport);
-void transport_data_completly_sent(subuser *sub, transport_t transport);
+void transport_data_completly_sent(subuser *sub, transport_t transport, acetables *g_ape);
 void transport_start(acetables *g_ape);
 void transport_free(acetables *g_ape);
 struct _transport_properties *transport_get_properties(transport_t transport, acetables *g_ape);

--- a/src/users.c
+++ b/src/users.c
@@ -583,7 +583,6 @@ void delsubuser(subuser **current, acetables *g_ape)
 		del->wait_for_free = 1;
 		do_died(del, g_ape);
 	} else {
-		g_ape->co[del->client->fd]->attach = NULL;
 		free(del);
 	}
 	

--- a/src/users.h
+++ b/src/users.h
@@ -216,7 +216,7 @@ USERS *seek_user_simple(const char *nick, acetables *g_ape);
 
 void deluser(USERS *user, acetables *g_ape);
 
-void do_died(subuser *user);
+void do_died(subuser *user, acetables *g_ape);
 
 void check_timeout(acetables *g_ape, int *last);
 void grant_aceop(USERS *user);

--- a/src/utils.c
+++ b/src/utils.c
@@ -30,7 +30,7 @@ void *xmalloc(size_t size)
 {
 	void *r = malloc(size);
 	if (r == NULL) {
-		printf("[ERR] Not enougth memory\n");
+		printf("[ERR] Not enough memory to xmalloc %lu\n", (unsigned long)size);
 		exit(0);
 	}
 	return r;
@@ -40,7 +40,7 @@ void *xrealloc(void *ptr, size_t size)
 {
 	void *r = realloc(ptr, size);
 	if (r == NULL) {
-		printf("[ERR] Not enougth memory\n");
+		printf("[ERR] Not enough memory to realloc %lu\n", (unsigned long)size);
 		exit(0);
 	}
 	return r;
@@ -183,7 +183,7 @@ char *xstrdup(const char *s)
 {
 	char *x = strdup(s);
 	if (x == NULL) {
-		printf("[ERR] Not enougth memory\n");
+		printf("[ERR] Not enough memory\n");
 		exit(0);	
 	}
 	return x;


### PR DESCRIPTION
Fix APE_Server seg fault crashes when user QUITs while buffered socket data still being written.
Fix memory leak when using syslog.
Fix processing of Content-Length header in single-packet HTTP responses.
