### PR TITLE
Update json.c

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -844,7 +844,7 @@ json_item *init_json_parser(const char *json_string)
 
 	jc = new_JSON_parser(&config);
 
-	for (pRaw = json_string; *pRaw; pRaw++) {
+	for (pRaw = json_string; (unsigned char)*pRaw; pRaw++) {
 		if (!JSON_parser_char(jc, *pRaw)) {
 			free_json_item(jcx.head);
 		    delete_JSON_parser(jc);


### PR DESCRIPTION
a cast to unsigned char was needed on my 64 bit machine to handle utf8-encoded strings correctly.
