### PR TITLE
Set JSONP http 'content type' header

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -271,6 +271,9 @@ struct _ape_socket {
 #define HEADER_XHR "HTTP/1.1 200 OK\r\nPragma: no-cache\r\nCache-Control: no-cache, must-revalidate\r\nExpires: Thu, 27 Dec 1986 07:30:00 GMT\r\nContent-Type: application/x-ape-event-stream\r\n\r\n                                                                                                                                                                                                                                                                "
 #define HEADER_XHR_LEN 421
 
+#define HEADER_JSONP "HTTP/1.1 200 OK\r\nPragma: no-cache\r\nCache-Control: no-cache, must-revalidate\r\nExpires: Thu, 27 Dec 1986 07:30:00 GMT\r\nContent-Type: application/javascript\r\n\r\n"
+#define HEADER_JSONP_LEN 157
+
 #define CONTENT_NOTFOUND "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\"><html><head><title>APE Server</title></head><body><h1>APE Server</h1><p>No command given.</p><hr><address>http://www.ape-project.org/ - Server "_VERSION" (Build "__DATE__" "__TIME__")</address></body></html>"
 
 /* http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-55 : The first three lines in each case are hard-coded (the exact case and order matters); */

--- a/src/raw.c
+++ b/src/raw.c
@@ -407,7 +407,7 @@ int send_raws(subuser *user, acetables *g_ape)
 				finish &= http_send_headers(user->headers.content, HEADER_SSE, HEADER_SSE_LEN, user->client, g_ape);
 				break;
 			case TRANSPORT_JSONP:
-				finish &= http_send_headers(user->headers.content, HEADER_JSONP, HEADER_JSONP_LEN, client, g_ape);
+				finish &= http_send_headers(user->headers.content, HEADER_JSONP, HEADER_JSONP_LEN, user->client, g_ape);
 			break;
 			case TRANSPORT_WEBSOCKET:
 			case TRANSPORT_WEBSOCKET_IETF:

--- a/src/raw.c
+++ b/src/raw.c
@@ -279,6 +279,9 @@ int send_raw_inline(ape_socket *client, transport_t transport, RAW *raw, acetabl
 		case TRANSPORT_SSE_LONGPOLLING:
 			finish &= http_send_headers(NULL, HEADER_SSE, HEADER_SSE_LEN, client, g_ape);
 			break;
+		case TRANSPORT_JSONP:
+			finish &= http_send_headers(NULL, HEADER_JSONP, HEADER_JSONP_LEN, client, g_ape);
+			break;
 		case TRANSPORT_WEBSOCKET:
 		case TRANSPORT_WEBSOCKET_IETF:
 			break;
@@ -403,6 +406,9 @@ int send_raws(subuser *user, acetables *g_ape)
 			case TRANSPORT_SSE_LONGPOLLING:
 				finish &= http_send_headers(user->headers.content, HEADER_SSE, HEADER_SSE_LEN, user->client, g_ape);
 				break;
+			case TRANSPORT_JSONP:
+				finish &= http_send_headers(user->headers.content, HEADER_JSONP, HEADER_JSONP_LEN, client, g_ape);
+			break;
 			case TRANSPORT_WEBSOCKET:
 			case TRANSPORT_WEBSOCKET_IETF:
 				break;


### PR DESCRIPTION
to 'application/javascript' instead of default header of 'text/html'

This removes 'warnings' in google chrome console when using APE_JSF
