### PR TITLE
Implemented output enhancements to Ape.log()

### DIFF
--- a/scripts/framework/log.js
+++ b/scripts/framework/log.js
@@ -1,0 +1,88 @@
+/*
+ * Enhance Ape.log function
+ */
+Apelog = Ape.log;
+Ape.log = function(data){
+	switch(typeof data){
+		case "object":
+			var result = "----" + data + "----\n";
+			var level = 0;
+			data = data.toSource();
+
+			for(var i= 0; data.length > i; i++){
+				var letter = data[i];
+				var next = data[i+1];
+				var previous = data[i-1];
+
+				var tab = false;
+
+				if(letter != " "){
+					result += letter;
+
+					switch(letter){
+						case "{":
+							if(next != "}"){
+								result += "\n";
+								level++;
+								tab = true;
+							}
+							break;
+						case "}":
+							if(previous != "{" && next != "," && next != ")"){
+								result += "\n";
+								level--;
+								tab = true;
+							}else if(next == "}"){
+								result += "\n";
+								level--;
+								tab = true;
+							}
+							break;
+						case "[":
+							if(next != "]"){
+								result += "\n";
+								level++;
+								tab = true;
+							}
+							break;
+						case "]":
+							if(previous != "[" && next != ","){
+								result += "\n";
+								level--;
+								tab = true;
+							}else if(next == "]"){
+								result += "\n";
+								level--;
+								tab = true;
+							}
+							break;
+
+						case ",":
+							if(next != "{"){
+								result += "\n";
+								tab = true;
+							}
+							break
+						case ":":
+							result += " ";
+							break;
+
+						default:
+							if(next == "}" || next == "]"){
+								result += "\n";
+								level--;
+								tab = true;
+							}
+
+					}
+					if(tab)
+						for(var l=0; level > l; l++)
+							result += "  ";
+				}
+			}
+			Apelog(result);
+			break;
+		default:
+			Apelog(data);
+	}
+}

--- a/scripts/main.ape.js
+++ b/scripts/main.ape.js
@@ -2,6 +2,7 @@ Ape.addEvent("init", function() {
 	include("framework/mootools.js");
 	include("framework/Http.js");
 	include("framework/userslist.js");
+	include("framework/log.js"); //Enhanced Ape.log() method, comment this line to disable it.
 	include("utils/utils.js");
 	include("commands/proxy.js");
 	include("commands/inlinepush.js");


### PR DESCRIPTION
Added the ability to `Ape.log()` to output the actual structure of a complex object to the console. Assuming `data` is a complex object the current output would be:

```
[object Object]
```

with these update it would be something like:

```
({
  0: #1={
    pipe: {},
    channels: {
      music: {
        pipe: {},
        users: {
          '09596760c3bd9ec6ff804f24812546eb': #1#
        }
      }
    },
    text: "helloworld",
    chans: [
      {
        pipe: {},
        userslist: {}
      },{
        pipe: {},
        userslist: {}
      }
    ]
  }
})
```

The `#1=` refers to a reference definition, while `#1#` references the same object define by `#1=`
