### PR TITLE
Reset http->pos

### DIFF
--- a/scripts/main.ape.js
+++ b/scripts/main.ape.js
@@ -19,7 +19,7 @@ Ape.addEvent('init', function() {
 
 
 		//This file is needed for the APE JSF diagnostic tool, once APE is installed you can remove it
-		///include('utils/checkTool.js');
+		include('utils/checkTool.js');
 
 		//This file is used to test features of APE. Especially meant for develompment of APE Features
 		//include('test/_tests.js');

--- a/src/http.c
+++ b/src/http.c
@@ -545,6 +545,7 @@ void process_http(ape_socket *co, acetables *g_ape)
 					parser->onready(parser, g_ape);
 					parser->ready = -1;
 					buffer->length = 0;
+					http->pos = 0;
 					return;
 				} else if (http->type == HTTP_GET_WS) { /* WebSockets handshake needs to read 8 bytes */
 					//urldecode(http->uri);


### PR DESCRIPTION
Reset the http reader position to the begenning when a line is fully
read. Shouldn't be usefull in most cases, but cause error (BAD_JSON) if
the socket isn't closed between two requests and a request is smaller
than the previous one.

Fix a problem I had while connecting to APE using a normal socket
client.
