### PR TITLE
Remove invalid JSON character escaping

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -226,10 +226,6 @@ static int escape_json_string(char *in, char *out, int len)
 				out[e++] = '\\';
 				out[e] = 'r';
 				break;
-			case '\'':
-				out[e++] = '\\';
-				out[e] = '\'';
-				break;
 			default: 
 				out[e] = in[i];
 				break;


### PR DESCRIPTION
These 4 lines were added 4th April 2012, but escaping `'` characters violates the JSON spec. If the server side sends a RAW containing an escaped `'` character, the client side JSON.parse in apeCore.js throws an unhandled exception and breaks the APE application in the browser.

The original intention seems to have been a fix for the JSONP transport.  So if this is still required it should only apply to JSONP and not globally.
